### PR TITLE
Add default args to fix example on ST3

### DIFF
--- a/hooks.py
+++ b/hooks.py
@@ -44,7 +44,7 @@ class HooksListener(sublime_plugin.EventListener):
                 raise Exception('Scope key "%s" for `hooks` plugin was not recognized.')
 
         # Run the command in its scope
-        scope.run_command(cmd['command'], cmd.get('args', ''))
+        scope.run_command(cmd['command'], cmd.get('args', {}))
 
 
 # Set up all hooks


### PR DESCRIPTION
The "on_post_save_user": [{"command": "select_all"}] example gives a KeyError on Linux Build 3054.
