### PR TITLE
Expand variables within args

### DIFF
--- a/hooks.py
+++ b/hooks.py
@@ -43,8 +43,13 @@ class HooksListener(sublime_plugin.EventListener):
             # Otherwise, complain
                 raise Exception('Scope key "%s" for `hooks` plugin was not recognized.')
 
+        args = cmd.get('args', {})
+        if view.window():
+            variables = view.window().extract_variables()
+            args = sublime.expand_variables(args, variables)
+
         # Run the command in its scope
-        scope.run_command(cmd['command'], cmd.get('args', {}))
+        scope.run_command(cmd['command'], args)
 
 
 # Set up all hooks

--- a/hooks.py
+++ b/hooks.py
@@ -37,10 +37,10 @@ class HooksListener(sublime_plugin.EventListener):
             if scope_key == 'app':
                 scope = sublime
             elif scope_key == 'window':
-            # Otherwise if it is window, move to window
+                # Otherwise if it is window, move to window
                 scope = view.window() or sublime.active_window()
             else:
-            # Otherwise, complain
+                # Otherwise, complain
                 raise Exception('Scope key "%s" for `hooks` plugin was not recognized.')
 
         args = cmd.get('args', {})


### PR DESCRIPTION
Thanks for building this awesome plugin! I noticed #11 and couldn't resist trying to find a way to fix that. So here is a PR which makes it possible to use variables like `$file` and `$folder` within the args of the command of the hook.

The sublime build system allows for using some variables that will be expanded when the build system is run, such as `$file`, `$folder`, etc. as documented [here](https://www.sublimetext.com/docs/api_reference.html#sublime.Window.extract_variables).

They also provide an API for doing the same thing:

* [Extracting the variables](https://www.sublimetext.com/docs/api_reference.html#sublime.Window.extract_variables)
* [Expanding the variables](https://www.sublimetext.com/docs/api_reference.html#sublime.expand_variables)

I used these to create a variables dict with relevant values. And instead of using the `$file_name` from the window variables, which actually is the filename of the active view in the window, I use the view from which the event was triggered to figure out the actual filename.

Example of how those variables can be used:
```json
"on_post_save_user": [
  {
    "command": "exec",
    "args": {
      "cmd": ["echo", "$file, $file_path, $file_base_name, $file_extension, $file_name"],
      "quiet": false
    },
    "scope": "window"
  }
]
```